### PR TITLE
Simply python3

### DIFF
--- a/zmq_subscriber.py
+++ b/zmq_subscriber.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 
 import time, datetime
 import zmq


### PR DESCRIPTION
With header /usr/bin/env python3.5 doesn't run with the last python3 (3.6), so imho it's better not specify the subversion (.5, .6 and so on), simply leaving "python3".

Tested with Python 3.6.3 onVM "Linux misp" (Ubuntu kernel 4.13 x64)