### PR TITLE
Fix invalid coordinate

### DIFF
--- a/helpers/geo_helper.py
+++ b/helpers/geo_helper.py
@@ -210,7 +210,7 @@ class Geo_helper:
     # adjust latitude and longitude to fit the limit, as specified
     # by EPSG:900913 / EPSG:3785 / OSGEO:41001
     # coord_list = [lat, lon]
-    def coordinate_list_valid(coord_list):
+    def coordinate_list_valid(self, coord_list):
         lat = coord_list[0]
         lon = coord_list[1]
         if (-180 <= lon <= 180) and (-85.05112878 <= lat <= 85.05112878):

--- a/helpers/geo_helper.py
+++ b/helpers/geo_helper.py
@@ -211,8 +211,8 @@ class Geo_helper:
     # by EPSG:900913 / EPSG:3785 / OSGEO:41001
     # coord_list = [lat, lon]
     def coordinate_list_valid(self, coord_list):
-        lat = int(coord_list[0])
-        lon = int(coord_list[1])
+        lat = float(coord_list[0])
+        lon = float(coord_list[1])
         if (-180 <= lon <= 180) and (-85.05112878 <= lat <= 85.05112878):
             return True
         else:

--- a/helpers/geo_helper.py
+++ b/helpers/geo_helper.py
@@ -101,7 +101,7 @@ class Geo_helper:
             ordDic['categ'] = categ
             ordDic['value'] = supposed_ip
             coord_list = [coord['lat'], coord['lon']]
-            if self.coordinate_list_valid(coord_list):
+            if not self.coordinate_list_valid(coord_list):
                 raise InvalidCoordinate("Coordinate do not match EPSG:900913 / EPSG:3785 / OSGEO:41001")
             self.push_to_redis_zset(self.keyCategCoord, json.dumps(ordDic))
             self.push_to_redis_zset(self.keyCategCountry, rep['full_rep'].country.iso_code)
@@ -146,7 +146,7 @@ class Geo_helper:
             ordDic['lat'] = coord_dic['lat']
             ordDic['lon'] = coord_dic['lon']
             coord_list = [coord['lat'], coord['long']]
-            if self.coordinate_list_valid(coord_list):
+            if not self.coordinate_list_valid(coord_list):
                 raise InvalidCoordinate("Coordinate do not match EPSG:900913 / EPSG:3785 / OSGEO:41001")
             self.push_to_redis_zset(self.keyCategCoord, json.dumps(ordDic))
             self.push_to_redis_zset(self.keyCategCountry, country_code)
@@ -167,6 +167,8 @@ class Geo_helper:
             self.logger.info('Published: {}'.format(json.dumps(to_send)))
         except phonenumbers.NumberParseException:
             self.logger.warning("Can't resolve phone number country")
+        except InvalidCoordinate:
+            self.logger.warning("Coordinate do not follow redis specification")
 
     ''' UTIL '''
     def push_to_redis_geo(self, keyCateg, lon, lat, content):

--- a/helpers/geo_helper.py
+++ b/helpers/geo_helper.py
@@ -211,8 +211,8 @@ class Geo_helper:
     # by EPSG:900913 / EPSG:3785 / OSGEO:41001
     # coord_list = [lat, lon]
     def coordinate_list_valid(self, coord_list):
-        lat = coord_list[0]
-        lon = coord_list[1]
+        lat = int(coord_list[0])
+        lon = int(coord_list[1])
         if (-180 <= lon <= 180) and (-85.05112878 <= lat <= 85.05112878):
             return True
         else:

--- a/zmq_dispatcher.py
+++ b/zmq_dispatcher.py
@@ -203,7 +203,7 @@ def handler_attribute(zmq_name, jsonobj, hasAlreadyBeenContributed=False):
         if type(field) is list:
             to_join = []
             for subField in field:
-                to_join.append(getFields(jsonobj, subField))
+                to_join.append(str(getFields(jsonobj, subField)))
             to_add = cfg.get('Dashboard', 'char_separator').join(to_join)
         else:
             to_add = getFields(jsonobj, field)


### PR DESCRIPTION
Fix #60 
In some cases, the coordinate given to redis may not match ``EPSG:900913 / EPSG:3785 / SGEO``, throwing an error. This fix adds a check and skip the addition if it occurs