### PR TITLE
removed hard-coded zmq startup

### DIFF
--- a/start_all.sh
+++ b/start_all.sh
@@ -69,4 +69,4 @@ else
 fi
 
 sleep 0.1
-sudo -u zmqs /bin/bash /var/www/misp-dashboard/start_zmq.sh &
+/bin/bash ./start_zmq.sh &

--- a/start_all.sh
+++ b/start_all.sh
@@ -69,4 +69,4 @@ else
 fi
 
 sleep 0.1
-/bin/bash ./start_zmq.sh &
+sudo -u zmqs /bin/bash ${DIR}/start_zmq.sh &


### PR DESCRIPTION
It was hard coded to run as a specific user and a hard coded location of script