### PR TITLE
chg: [auth] conditionally send debug token

### DIFF
--- a/server.py
+++ b/server.py
@@ -113,7 +113,6 @@ class User(UserMixin):
             "data[_Token][key]": "",
             "data[_Token][fields]": "",
             "data[_Token][unlocked]": "",
-            # "data[_Token][debug]": "",
             "data[User][email]": self.id,
             "data[User][password]": self.password,
         }
@@ -140,7 +139,11 @@ class User(UserMixin):
 
         post_data["data[_Token][fields]"] = token_fields.group(1)
         post_data["data[_Token][key]"] = token_key.group(1)
-        # post_data["data[_Token][debug]"] = token_debug.group(1)
+
+        # debug_token should return None when MISP debug is off.
+        # Only send debug_token when MISP is running in debug mode.
+        if token_debug is not None:
+            post_data["data[_Token][debug]"] = token_debug.group(1)
 
         # POST request with user credentials + hidden form values.
         post_to_login_page = session.post(misp_login_page, data=post_data, allow_redirects=False)

--- a/server.py
+++ b/server.py
@@ -113,7 +113,7 @@ class User(UserMixin):
             "data[_Token][key]": "",
             "data[_Token][fields]": "",
             "data[_Token][unlocked]": "",
-            "data[_Token][debug]": "",
+            # "data[_Token][debug]": "",
             "data[User][email]": self.id,
             "data[User][password]": self.password,
         }
@@ -140,7 +140,7 @@ class User(UserMixin):
 
         post_data["data[_Token][fields]"] = token_fields.group(1)
         post_data["data[_Token][key]"] = token_key.group(1)
-        post_data["data[_Token][debug]"] = token_debug.group(1)
+        # post_data["data[_Token][debug]"] = token_debug.group(1)
 
         # POST request with user credentials + hidden form values.
         post_to_login_page = session.post(misp_login_page, data=post_data, allow_redirects=False)


### PR DESCRIPTION
`post_data` sent by `misp_login()` should only send a debug token when MISP is running in debug mode.

This commit changes the default behaviour to only send `data[_Token][debug]` when the value is matched in the MISP login page.

See https://github.com/MISP/misp-dashboard/issues/136#issue-515808069